### PR TITLE
fixed crash on startup (windows and msvc)

### DIFF
--- a/src/utils/window.hpp
+++ b/src/utils/window.hpp
@@ -7,9 +7,9 @@
 #include <Daxa.hpp>
 
 struct Window {
-    GLFWwindow *window_ptr;
+    GLFWwindow *window_ptr = nullptr;
     glm::ivec2 frame_dim{800, 800};
-    VkSurfaceKHR vulkan_surface;
+    VkSurfaceKHR vulkan_surface = VK_NULL_HANDLE;
 
     Window() {
         glfwInit();


### PR DESCRIPTION
If pointers are not explicitly initalized they can contain any random value.
the MSVC compiler doesn't set this to be the defaut `nullptr` in debug, but instead to `0xCDCDCDCD`.
This lead to the application crashing on startup, since `get_vksurface` wasn't initalizing the surface because of the `if (!vulkan_surface)` condition evaluating to false.