### PR TITLE
changed formatting of linker options given in CMake for MSVC

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -19,7 +19,7 @@ target_include_directories(${PROJECT_NAME} PRIVATE "src")
 target_include_directories(${PROJECT_NAME} PRIVATE ${STB_INCLUDE_DIRS})
 
 if(CMAKE_SYSTEM_NAME STREQUAL "Windows")
-    target_link_options(${PROJECT_NAME} PRIVATE "-Wl,/ENTRY:mainCRTStartup,/SUBSYSTEM:WINDOWS")
+    target_link_options(${PROJECT_NAME} PRIVATE -Wl /ENTRY:mainCRTStartup /SUBSYSTEM:WINDOWS)
     target_link_libraries(${PROJECT_NAME} PRIVATE Dwmapi)
 endif()
 


### PR DESCRIPTION
Previously, in Windows, some linker options in CMakeLists.txt were provided like this:

`target_link_options(${PROJECT_NAME} PRIVATE "-Wl,/ENTRY:mainCRTStartup,/SUBSYSTEM:WINDOWS")`

I believe this sends the entire string inside those quotes to the linker to be interpreted as a single argument, and I was getting the error back from MSVC that it was an unrecognized option (because it was treating the whole clump as a single option.)

Removing the quotes and the commas fixed the issue.